### PR TITLE
Flake8 python linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+max-line-length=120
+show-source=true
+statistics=true
+ignore= # Space before and after operator, to permit more readability
+    E221,
+    E222,
+    E272,
+    E211,
+    E202,
+    E241
+exclude=
+    ./protorepo/**/*
+per-file-ignores=
+    ./tests_recommendations.py: E501 
+    # Line length for long test texts

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # Lint with deactivated whitespace before/after operator check, and deactivated line length for unit tests file
-        # TODO: Config file
-        flake8 . --max-line-length=120 --show-source --statistics "--ignore=E221,E222,E272,E211,E202,E241" --exclude="./protorepo/*" --per-file-ignores="./tests_recommendations.py:E501"    
+        flake8    
       - name: Check errors with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,7 +37,12 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install coverage flake8
         misc/download_language_models.sh
-    - name: Check errors with flake8
+    - name: Lint with flake8
+      run: |
+        # Lint with deactivated whitespace before/after operator check, and deactivated line length for unit tests file
+        # TODO: Config file
+        flake8 . --max-line-length=120 --show-source --statistics "--ignore=E221,E222,E272,E211,E202,E241" --exclude="./protorepo/*" --per-file-ignores="./tests_recommendations.py:E501"    
+      - name: Check errors with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/custom_logger.py
+++ b/custom_logger.py
@@ -1,12 +1,20 @@
 from loguru import logger
 import json
 
+
 def __serialize(record):
-    subset = {"level": record["level"].name.lower(), "ts": record["time"].timestamp(), "msg": record["message"], **record["extra"]}
+    subset = {
+        "level": record["level"].name.lower(),
+        "ts":    record["time"].timestamp(),
+        "msg":   record["message"],
+        **record["extra"]
+    }
     return json.dumps(subset)
+
 
 def __sink(message):
     print(__serialize(message.record))
+
 
 def init_logger():
     logger.remove()

--- a/recommendation_interceptor.py
+++ b/recommendation_interceptor.py
@@ -1,8 +1,10 @@
 from grpc_interceptor import ServerInterceptor
 from grpc_interceptor.exceptions import GrpcException, Internal
 from loguru import logger
-import grpc, time
 from typing import Callable, Any
+import grpc
+import time
+
 
 class UnaryInterceptor(ServerInterceptor):
     def intercept(
@@ -13,9 +15,9 @@ class UnaryInterceptor(ServerInterceptor):
         method_name: str,
     ) -> Any:
         try:
-            duration = time.time()            
+            duration = time.time()
             res = method(request, context)
-            duration = time.time() - duration;
+            duration = time.time() - duration
             with logger.contextualize(time=duration, method=method_name):
                 logger.info("rpc")
             return res

--- a/recommendations_service.py
+++ b/recommendations_service.py
@@ -1,13 +1,13 @@
-import os, sys, json
+import os
 
-import grpc
 import protorepo.noted.recommendations.v1.recommendations_pb2_grpc as recommendationspb_grpc
-import protorepo.noted.recommendations.v1.recommendations_pb2      as recommendationspb
+import protorepo.noted.recommendations.v1.recommendations_pb2 as recommendationspb
 
 import pke
-from pke.lang import stopwords 
+from pke.lang import stopwords
 
 from loguru import logger
+
 
 class RecommendationsAPI(recommendationspb_grpc.RecommendationsAPIServicer):
 
@@ -15,14 +15,14 @@ class RecommendationsAPI(recommendationspb_grpc.RecommendationsAPIServicer):
 
     def __init__(self, *args, **kwargs):
         self.lang                =       os.getenv("RECOMMENDATIONS_SERVICE_LANG")                 or 'fr'
-        self.number_of_results   = int  (os.getenv("RECOMMENDATIONS_SERVICE_NUMBER_OF_KEYWORDS")   or 5   )  
-        self.n_gram_length       = int  (os.getenv("RECOMMENDATIONS_SERVICE_N_GRAM_LENGTH")        or 2   ) # between 1 and 3
-        self.co_occurence_window = int  (os.getenv("RECOMMENDATIONS_SERVICE_CO_OCCURENCE_WINDOW")  or 3   )  
-        self.threshold           = float(os.getenv("RECOMMENDATIONS_SERVICE_THRESHOLD")            or 0.75)            
+        self.number_of_results   = int  (os.getenv("RECOMMENDATIONS_SERVICE_NUMBER_OF_KEYWORDS")   or 5   )
+        self.n_gram_length       = int  (os.getenv("RECOMMENDATIONS_SERVICE_N_GRAM_LENGTH")        or 2   )
+        self.co_occurence_window = int  (os.getenv("RECOMMENDATIONS_SERVICE_CO_OCCURENCE_WINDOW")  or 3   )
+        self.threshold           = float(os.getenv("RECOMMENDATIONS_SERVICE_THRESHOLD")            or 0.75)
 
     def __candidate_selection_and_weighting(self):
         with logger.contextualize(n_gram_length=self.n_gram_length, co_occurence_window=self.co_occurence_window):
-            logger.debug(f"Candidate selection")
+            logger.debug("Candidate selection")
         self.extractor.candidate_selection(n=self.n_gram_length)
         self.extractor.candidate_weighting(window=self.co_occurence_window, use_stems=False)
 

--- a/server.py
+++ b/server.py
@@ -1,25 +1,27 @@
-import os, grpc
+import os
+import grpc
 import protorepo.noted.recommendations.v1.recommendations_pb2_grpc as recommendationspb_grpc
 
 from utils.env import get_required_env_variable
 
-from concurrent import futures 
+from concurrent import futures
 
 from recommendations_service import RecommendationsAPI
 from recommendation_interceptor import UnaryInterceptor
 from loguru import logger
 
+
 def serve():
-    port = get_required_env_variable("RECOMMENDATIONS_SERVICE_PORT");
-    max_workers = os.getenv("RECOMMENDATIONS_SERVICE_MAX_WORKERS") or 8;
+    port = get_required_env_variable("RECOMMENDATIONS_SERVICE_PORT")
+    max_workers = os.getenv("RECOMMENDATIONS_SERVICE_MAX_WORKERS") or 8
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers), interceptors=[UnaryInterceptor()])
 
     recommendationspb_grpc.add_RecommendationsAPIServicer_to_server(RecommendationsAPI(), server)
 
     with logger.contextualize(port=port):
-        logger.info(f"Opening server")
-    
+        logger.info("Opening server")
+
     server.add_insecure_port(f'[::]:{port}')
     server.start()
     server.wait_for_termination()

--- a/tests_recommendations.py
+++ b/tests_recommendations.py
@@ -1,20 +1,20 @@
 from recommendations_service import RecommendationsAPI
 import protorepo.noted.recommendations.v1.recommendations_pb2 as recommendationspb
 
-from collections import namedtuple
-
 from custom_logger import init_logger
-from loguru import logger
 
-import os , grpc, grpc_testing, unittest
+import os
+import grpc
+import grpc_testing
+import unittest
+
 
 class TestRecommendationsAPI(unittest.TestCase):
     def __init__(self, methodName):
         super().__init__(methodName)
         init_logger()
 
-
-    def setUp(self):        
+    def setUp(self):
         servicers = {
             recommendationspb.DESCRIPTOR.services_by_name['RecommendationsAPI']: RecommendationsAPI()
         }
@@ -23,17 +23,17 @@ class TestRecommendationsAPI(unittest.TestCase):
             servicers, grpc_testing.strict_real_time())
 
     def test_extract_keywords_empty_request(self):
-        """ expect to get an empty response response 
+        """ expect to get an empty response response
         """
         content = ""
         request = recommendationspb.ExtractKeywordsRequest(content=content)
 
         extract_keywords_method = self.test_server.invoke_unary_unary(
             method_descriptor=(recommendationspb.DESCRIPTOR
-                                .services_by_name['RecommendationsAPI']
-                                .methods_by_name['ExtractKeywords']),
+                               .services_by_name['RecommendationsAPI']
+                               .methods_by_name['ExtractKeywords']),
             invocation_metadata={},
-            request=request, 
+            request=request,
             timeout=None
         )
 
@@ -44,24 +44,24 @@ class TestRecommendationsAPI(unittest.TestCase):
         self.assertEqual(response.keywords, [])
 
     def test_extract_keywords_invalid_request_field(self):
-        """ expect to get a ValueError 
+        """ expect to get a ValueError
         """
         self.assertRaises(ValueError, recommendationspb.ExtractKeywordsRequest, invalid_field="")
 
     def test_extract_keywords_valid_request(self):
-        """ expect to get multiple keywords that are in the text 
+        """ expect to get multiple keywords that are in the text
         """
-        number_of_keywords = os.getenv("RECOMMENDATIONS_SERVICE_NUMBER_OF_KEYWORDS") or 5 # TODO: defaults.py
+        number_of_keywords = os.getenv("RECOMMENDATIONS_SERVICE_NUMBER_OF_KEYWORDS") or 5  # TODO: defaults.py
 
         content = "Les mathématiques se distinguent des autres sciences par un rapport particulier au réel car l'observation et l'expérience ne s'y portent pas sur des objets physiques ; les mathématiques ne sont pas une science empirique. Elles sont de nature entièrement intellectuelle, fondées sur des axiomes déclarés vrais ou sur des postulats provisoirement admis."
         request = recommendationspb.ExtractKeywordsRequest(content=content)
 
         extract_keywords_method = self.test_server.invoke_unary_unary(
             method_descriptor=(recommendationspb.DESCRIPTOR
-                                .services_by_name['RecommendationsAPI']
-                                .methods_by_name['ExtractKeywords']),
+                               .services_by_name['RecommendationsAPI']
+                               .methods_by_name['ExtractKeywords']),
             invocation_metadata={},
-            request=request, 
+            request=request,
             timeout=None
         )
 
@@ -76,9 +76,9 @@ class TestRecommendationsAPI(unittest.TestCase):
             self.assertTrue(keyword.lower() in content.lower())
 
     def test_extract_keywords_batch_valid_request(self):
-        """ expect to get multiple keywords for each text 
+        """ expect to get multiple keywords for each text
         """
-        number_of_keywords = os.getenv("RECOMMENDATIONS_SERVICE_NUMBER_OF_KEYWORDS") or 5 # TODO: defaults.py
+        number_of_keywords = os.getenv("RECOMMENDATIONS_SERVICE_NUMBER_OF_KEYWORDS") or 5  # TODO: defaults.py
 
         request = recommendationspb.ExtractKeywordsBatchRequest()
         request.contents.append("Historiens ont ignoré Vichy et collaboration. Comité d'histoire de la seconde guerre mondiale créé en 1951 brise le mythe resistancialiste dans les années 1960")
@@ -87,10 +87,10 @@ class TestRecommendationsAPI(unittest.TestCase):
 
         extract_keywords_batch_method = self.test_server.invoke_unary_unary(
             method_descriptor=(recommendationspb.DESCRIPTOR
-                                .services_by_name['RecommendationsAPI']
-                                .methods_by_name['ExtractKeywordsBatch']),
+                               .services_by_name['RecommendationsAPI']
+                               .methods_by_name['ExtractKeywordsBatch']),
             invocation_metadata={},
-            request=request, 
+            request=request,
             timeout=None
         )
 

--- a/utils/env.py
+++ b/utils/env.py
@@ -1,7 +1,8 @@
 import os
 
+
 def get_required_env_variable(name: str) -> str:
-    result = os.getenv(name);
+    result = os.getenv(name)
     if result is None:
         raise EnvironmentError(f"Please set the {name} env variable")
     return result


### PR DESCRIPTION
#### Description

Adds and apply Python8 flake linting.

Resolves DOD of #8 

#### Changelog

- [ENHANCEMENT] Linting with 120 characters max and with whitespaces before and after operators deactivated. Line length has been deactivated in the `tests_recommendation.py` file


Whitespace before/after operators has been deactivated in order to have more readable code in certain case, example:
```python
        self.lang                =       os.getenv("RECOMMENDATIONS_SERVICE_LANG")                 or 'fr'
        self.number_of_results   = int  (os.getenv("RECOMMENDATIONS_SERVICE_NUMBER_OF_KEYWORDS")   or 5   )
        self.n_gram_length       = int  (os.getenv("RECOMMENDATIONS_SERVICE_N_GRAM_LENGTH")        or 2   )
        self.co_occurence_window = int  (os.getenv("RECOMMENDATIONS_SERVICE_CO_OCCURENCE_WINDOW")  or 3   )
        self.threshold           = float(os.getenv("RECOMMENDATIONS_SERVICE_THRESHOLD")            or 0.75)
```
